### PR TITLE
Fix build with clang 4.0, libstdc++ 6.3

### DIFF
--- a/src/mocppcallbacks.h
+++ b/src/mocppcallbacks.h
@@ -19,6 +19,7 @@
 
 #include <clang/Lex/Preprocessor.h>
 #include <clang/Basic/Version.h>
+#include <set>
 
 class MocPPCallbacks : public clang::PPCallbacks {
     clang::Preprocessor &PP;


### PR DESCRIPTION
Current clang headers no longer #include <set> -- got to #include it
ourselves to make use of std::set

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>