### PR TITLE
fix clang-10 support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,7 @@ message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 Find_Package(Clang REQUIRED CONFIG HINTS "${LLVM_INSTALL_PREFIX}/lib/cmake/clang")
 message(STATUS "Found Clang in ${CLANG_INSTALL_PREFIX}")
 
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 14)
 
 SET(common_srcs mocng.cpp generator.cpp propertyparser.cpp mocppcallbacks.cpp mocastconsumer.cpp
                 qbjs.cpp clangversionabstraction.cpp workaroundtests.cpp)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -448,7 +448,13 @@ invalidArg:
 
   if (PreprocessorOnly) {
       Argv.push_back("-P");
-      clang::tooling::ToolInvocation Inv(Argv, new clang::PrintPreprocessedAction, &FM);
+      clang::tooling::ToolInvocation Inv(Argv,
+    #if CLANG_VERSION_MAJOR >= 10
+        std::make_unique<clang::PrintPreprocessedAction>(),
+    #else
+        new clang::PrintPreprocessedAction,
+    #endif
+        &FM);
       return !Inv.run();
   }
 
@@ -462,7 +468,13 @@ invalidArg:
       Argv.push_back("QtCore/qobject.h");
   }
 
-  clang::tooling::ToolInvocation Inv(Argv, new MocAction, &FM);
+  clang::tooling::ToolInvocation Inv(Argv,
+    #if CLANG_VERSION_MAJOR >= 10
+        std::make_unique<MocAction>(),
+    #else
+        new MocAction,
+    #endif
+        &FM);
 
   const EmbeddedFile *f = EmbeddedFiles;
   while (f->filename) {


### PR DESCRIPTION
- added preprocessor directives to:
  - support for clang/llvm >= 10 which uses smartptr's instead of rawpointers.
  - support for clang/llvm < 10 which uses raw pointers.
  - bump required C++ version from 11 to 14,
    since Clang-10 requires C++14 to build, and clang-9 builds fine with it.

tested so it builds fine with clang-9 + clang-10.